### PR TITLE
Suppression de mesure_similarite.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ mesure_similarite: mesure_similarite.o lecture_molecule_sdf.o fonctions_mces.o
 	gcc ${CFLAGS} mesure_similarite.o lecture_molecule_sdf.o fonctions_mces.o -o mesure_similarite
 	
 
-mesure_similarite.o: mesure_similarite.c mesure_similarite.h
+mesure_similarite.o: mesure_similarite.c
 	gcc ${CFLAGS} -c mesure_similarite.c
 
 fonctions_mces.o: fonctions_mces.c fonctions_mces.h 

--- a/mesure_similarite.c
+++ b/mesure_similarite.c
@@ -1,4 +1,4 @@
-#include "mesure_similarite.h"
+#include "fonctions_mces.h"
 
 double last_chrono;
 int main(int argc, char *argv[])

--- a/mesure_similarite.h
+++ b/mesure_similarite.h
@@ -1,1 +1,0 @@
-#include "fonctions_mces.h"


### PR DESCRIPTION
Fichier inutile :)
(ne contient qu'un include, un .h ne doit pas contenir d'include)
(le .c associé contient uniquement le main, il n'a pas de raison de devenir une bibliothèque
partagée)